### PR TITLE
Fixed interfering log message

### DIFF
--- a/mix_autocomplete.zsh
+++ b/mix_autocomplete.zsh
@@ -44,6 +44,7 @@ function _mix() {
 
     completions="$(
         mix run -e '
+          IO.puts("[abcdef]")
           Mix.Task.load_all
             |> Enum.map(&(Mix.Task.task_name &1))
             |> Enum.sort
@@ -51,8 +52,7 @@ function _mix() {
             |> (&(&1 ++ ["__end__"])).()
             |> Enum.join(" ")
             |> IO.puts
-        ' | grep -Po '(?<=(__start__)).*(?=__end__)')"
-
+        ' | awk -v FS='(__start__|__end__)' '{print $2}')"
     _store_cache mix mix_md5 completions
   fi
 

--- a/mix_autocomplete.zsh
+++ b/mix_autocomplete.zsh
@@ -41,10 +41,8 @@ function _mix() {
       # show a message explaining why we can't show completions?
       return 1
     fi
-
     completions="$(
         mix run -e '
-          IO.puts("[abcdef]")
           Mix.Task.load_all
             |> Enum.map(&(Mix.Task.task_name &1))
             |> Enum.sort

--- a/mix_autocomplete.zsh
+++ b/mix_autocomplete.zsh
@@ -47,9 +47,11 @@ function _mix() {
           Mix.Task.load_all
             |> Enum.map(&(Mix.Task.task_name &1))
             |> Enum.sort
+            |> (&([ "__start__" | &1])).()
+            |> (&(&1 ++ ["__end__"])).()
             |> Enum.join(" ")
             |> IO.puts
-        ')"
+        ' | grep -Po '(?<=(__start__)).*(?=__end__)')"
 
     _store_cache mix mix_md5 completions
   fi


### PR DESCRIPTION
I had the problem that sometimes an `:info` log would appear and cause the whole process to fail.
I now added a start and an end tag around the options and grep for things in between them.
Sounds stupid, looks stupid, but works like a charm